### PR TITLE
Update UnscalableLoopFinder_Narrow.py

### DIFF
--- a/MissingEntryCriteriaFinder
+++ b/MissingEntryCriteriaFinder
@@ -1,0 +1,52 @@
+#Find any record-triggered flows without starting entry criteria aka flows that always run without any condition check
+
+#PREP: In Finder, select all returned flows in flows folder and replace .flow with .xml
+#To Call in Terminal: python3 MissingEntryCriteriaFinder.py "File Path to Flows" "Output File Label"
+#Example file path: /Users/username/Desktop/OrgName/PackageName/flows
+#Example outout file name: FlowResults_MissingEntryCriteria-DevSandboxA.txt with DevSandboxA as the provided input
+
+
+from sys import argv
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+NAMESPACE = '{http://soap.sforce.com/2006/04/metadata}'
+TRIGGERTYPE_REFERENCE = f'{NAMESPACE}start/{NAMESPACE}recordTriggerType'
+FILTER_REFERENCE = f'{NAMESPACE}start/{NAMESPACE}filters'
+
+
+#Create new file for list of file names of flows missing entry conditions in their start element
+def outputToFile(infile, orgName):
+    # a = append / Later: Create xlxs file and add counter for each identified issue
+    with open(f'FlowResults_MissingEntryCriteria-{orgName}.txt', 'a') as outfile:
+        outfile.write(f'{infile}\n')
+        print(f'{infile}')
+
+        
+def entryFilterCheck(folderPath, infile, orgName):
+    root = ET.parse(folderPath / infile).getroot()
+    flowFound = False
+
+    if root.find(f'{NAMESPACE}status').text == 'Active' and (root.find(TRIGGERTYPE_REFERENCE) is not None):
+       # check for entry criteria
+      if root.find(FILTER_REFERENCE) is None:
+            outputToFile(infile, orgName)
+            flowFound = True
+    
+    return flowFound
+
+
+def commandLineParser(flowsPath, orgName):
+    overallFlowFound = False
+    #iterate directory - go through all the files in the folder above and call the main function
+    #only look at xml files
+    for filePath in [f for f in flowsPath.iterdir() if f.suffix == '.xml']:
+        if entryFilterCheck(flowsPath, filePath.name, orgName):
+            overallFlowFound = True
+    return overallFlowFound
+
+
+if __name__ == "__main__":
+    overallFlowFound = commandLineParser(Path(argv[1]), argv[2])
+    if not overallFlowFound:
+        print('No Active Record-Triggered Flows with missing entry criteria.')

--- a/README.md
+++ b/README.md
@@ -4,8 +4,13 @@ A collection of scripts and rulesets to use over Salesforce Flow XML Metadata to
 ## March 2022: Initial Stage ##  
 Starting with something simple, that is often a go-to manual check in an org review or an analysis of current state of scalability. 
 
+## Feb 2024: Loop Finder 2.0 and Missing Entry Criteria Finder ##  
+Fixed the narrow version of the loop finder to account for more accurate scenarios such as referencing the Loop directly in input values in DML elements, as opposed to just filter values, and referencing loop single variables in input and filter elements. This still does not identify loop name or loop single variable references inside of flow formulas. 
+
+Missing Entry Criteria class added to output a list of record-triggered flows that don't have entry critera as another starting point for improving an org's process automation performance or assessing quality and efficiency.
+
 **Unscalable Flow Identifier: SOQL or DML inside of Loops**  
-Currently we can identify Get Records, Create Records, Update Records, and Delete Records elements inside of Loops based on an explicit reference to the Loop item inside of the element
+Currently we can identify Get Records, Create Records, Update Records, and Delete Records elements inside of Loops based on an explicit reference to the Loop or Loop item inside of the element
 
 Example of a Loop tag within a Flow XML file (with invalid replaced names):
 ```
@@ -26,7 +31,7 @@ Example of a Loop tag within a Flow XML file (with invalid replaced names):
     </loops>
 ```
 
-Example of a Get Records (SOQL) referencing a Loop item (with invalid replaced names):
+Example of a Get Records (SOQL) referencing a Loop item (with invalid replaced names) in Filters:
 ```
 <Flow ...    
     <recordLookups>
@@ -52,6 +57,48 @@ Example of a Get Records (SOQL) referencing a Loop item (with invalid replaced n
             <field>Field API Name</field>
         </outputAssignments>
     </recordLookups>
+```
+Example of a Loop defining a single variable and a Create Records (DML) referencing that loop's single variable (with invalid replaced names) in Values:
+```
+<loops>
+        <name>Loop_Accounts</name>
+        <label>Loop Accounts</label>
+        <locationX>1969</locationX>
+        <locationY>1156</locationY>
+        <assignNextValueToReference>singleLoopVariable</assignNextValueToReference>
+        <collectionReference>get_accounts</collectionReference>
+        <iterationOrder>Asc</iterationOrder>
+        <nextValueConnector>
+            <targetReference>get_contacts</targetReference>
+        </nextValueConnector>
+        <noMoreValuesConnector>
+            <targetReference>update_flow_stage</targetReference>
+        </noMoreValuesConnector>
+    </loops>
+……
+<recordCreates>
+        <name>Create_Contact</name>
+        <label>Create Contact</label>
+        <locationX>2094</locationX>
+        <locationY>1340</locationY>
+        <connector>
+            <targetReference>Loop_Accounts</targetReference>
+        </connector>
+        <inputAssignments>
+            <field>OwnerId</field>
+            <value>
+                <elementReference>singleLoopVariable.OwnerId</elementReference>
+            </value>
+        </inputAssignments>
+        <inputAssignments>
+            <field>Type</field>
+            <value>
+                <elementReference>AccountOwner</elementReference>
+            </value>
+        </inputAssignments>
+        <object>Contact</object>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordCreates>
 ```
 
 **Future Additions:**  

--- a/UnscalableLoopFinder_Narrow.py
+++ b/UnscalableLoopFinder_Narrow.py
@@ -1,13 +1,13 @@
 ##############################################################################
 #Author: Monica Thornton Hill 
-#Date: March 2022
-#Description: Identify SOQL and DML inside of Loops
+#Date: Feb 2024
+#Description: Identify SOQL and DML inside of Loops in Salesforce Flows
 #Currently this program only identifies SOQL/DML elements that explicity reference a loop, 
 #not SOQL/DML inside of loops that don't use the loop item which does seem to happen.
-#Disclaimer: I'm not a Python developer. Attempt #1.
+#Disclaimer: I'm not a Python developer. Attempt #2.
 
-#Current State: Get Loop Names to check against SOQL/DML Elements [elementtype]->filters->value>elementReference 
-#Unaccounted for 1st Element in Loop check: Get SOQL/DML Element names to check against Loops->nextValueConnector->targetReference
+#Current State: Get Loop Names and Loop single variables if defined to check against SOQL/DML Elements [elementtype]->filters->value>elementReference 
+#Unaccounted for Element in Loop check: Get SOQL/DML Element names to check against Loops->nextValueConnector->targetReference
 
 #TO ADD LATER: To catch elements inside loop not explicitly referencing the Loop -
 # For any elements identified from the above's Current State check - get element Name
@@ -21,80 +21,88 @@
 
 
 #PREP: In Finder, select all returned flows in flows folder and replace .flow with .xml
-#To Call in Terminal: python3 UnscalableLoopFinder_Narrow.py "File Path to Flows" "Output File Name"
+#To Call in Terminal: python3 UnscalableLoopFinder_Narrow.py "File Path to Flows" "Output File Label"
 #Example file path: /Users/username/Desktop/OrgName/PackageName/flows
+#Example output file name: FlowLoopResults-Narrow-DevSandboxA.txt
 
 
-import xml.etree.ElementTree as ET
 from sys import argv
 from pathlib import Path
+import xml.etree.ElementTree as ET
 
 NAMESPACE = '{http://soap.sforce.com/2006/04/metadata}'
-#path to folder with flows
-flowsPath = Path(argv[1])
+LOOPS = f'{NAMESPACE}loops'
+LOOP_NAME = f'{NAMESPACE}name'
+LOOP_VARIABLE = f'{NAMESPACE}assignNextValueToReference'
+FILTERS_ELEMENT_REFERENCE = f'/{NAMESPACE}filters/{NAMESPACE}value/{NAMESPACE}elementReference'
+INPUTS_ELEMENT_REFERENCE = f'/{NAMESPACE}inputAssignments/{NAMESPACE}value/{NAMESPACE}elementReference'
 
 
-#Get all loop names in a flow XML file
-def processRoots(folderPath,infile):
-    # ET.parse(infile) is the tree and is uneeded
+def findAllLoops(folderPath, infile):
     root = ET.parse(folderPath / infile).getroot()
-    # print(root)
-    # "list comprehension" - python list creation in one line
-    loopList = [loop.find(f'{NAMESPACE}name').text for loop in root.findall(f'{NAMESPACE}loops')]
-    return root, loopList
+    # not all loops have assignNextValue aka a single loop variable defined... loop.find will return None if none are found
+    loopVariableNames = [loop.find(LOOP_VARIABLE) for loop in root.findall(LOOPS)]
+    return root, [loop.find(LOOP_NAME).text for loop in root.findall(LOOPS)] + \
+                 [loopVariable.text for loopVariable in loopVariableNames if loopVariable is not None]
+
+
+def containsCheck(strings, sub):
+    # generator to check if string is found in the reference - https://stackoverflow.com/questions/13779526/finding-a-substring-within-a-list-in-python
+    return next((s for s in strings if sub in s), None)
 
 
 #Iterate through the loops tags' names to check for any references in record Flow Elements
-def processRecordLoop(root, loopList, targetElement):
-    for loopName in loopList:
-        potentialLoops = root.findall(f'{NAMESPACE}{targetElement}/{NAMESPACE}filters/{NAMESPACE}value/{NAMESPACE}elementReference')
-        for potentialLoop in potentialLoops:
-            if potentialLoop.text == loopName:
-                return True
-    return False
+def elementCheck(root, loopList, targetElement):
+    def elementCheckHelper(elementReferenceType):
+        elementReferences = root.findall(f'{NAMESPACE}{targetElement}{elementReferenceType}')
+        return [x for x in loopList if containsCheck([potential.text for potential in elementReferences], x)]
+    # Filter references are used in SOQL directly in Get Records Elements or as part of DML Elements
+    # Input references are used in DML Elements
+    bad_filters = elementCheckHelper(FILTERS_ELEMENT_REFERENCE)
+    bad_inputs = elementCheckHelper(INPUTS_ELEMENT_REFERENCE)
+    return (bad_filters != []) or (bad_inputs != [])
 
 
 #Create new file for list of file names and identified bad practice
-def outputToFile(infile,identifier,orgName):
+def outputToFile(infile, identifier, orgName):
     # a = append / Later: Create xlxs file and add counter for each identified issue
     with open(f'FlowLoopResults-Narrow-{orgName}.txt', 'a') as outfile:
         outfile.write(f'{identifier} : {infile}\n')
         print(f'{identifier} : {infile}')
 
 
-#main function
-def processOutput(folderPath,infile,orgName):
-    root, loopList = processRoots(folderPath,infile)
-    status = root.find(f'{NAMESPACE}status').text
-
+def loopCheck(folderPath, infile, orgName):
+    root, loopList = findAllLoops(folderPath, infile)
     flowFound = False
 
-    if status == 'Active':
-        #Record Lookups Elements - SOQL Check
-        if processRecordLoop(root, loopList, 'recordLookups'):
+    def processToOutput(targetElement, identifier):
+        if elementCheck(root, loopList, targetElement):
+            outputToFile(infile, identifier, orgName)
+            nonlocal flowFound
             flowFound = True
-            outputToFile(infile,'SOQL',orgName)
-            
-        #Record Create Elements - DML Check
-        if processRecordLoop(root, loopList, 'recordCreates'):
-            flowFound = True
-            outputToFile(infile,'DML ',orgName)
 
-        #Record Delete Elements - DML Check
-        if processRecordLoop(root, loopList, 'recordDeletes'):
-            flowFound = True
-            outputToFile(infile,'DML ',orgName)
+    if root.find(f'{NAMESPACE}status').text == 'Active':
+        # check all Get Records elements
+        processToOutput('recordLookups', 'SOQL')
+        # check all Create/Update/Delete Records elements
+        processToOutput('recordCreates', 'DML ')
+        processToOutput('recordDeletes', 'DML ')
+        processToOutput('recordUpdates', 'DML ')
     
     return flowFound
 
-#iterate directory - go through all the files in the folder above and call the main function
-overallFlowFound = False
-for filePath in flowsPath.iterdir():
-    flowFound = processOutput(flowsPath, filePath.name, argv[2])
-    if flowFound:
-        overallFlowFound = True
-    #print(f'{overallFlowFound} - {flowFound}')
-    #Later: Add Count in processOutput for each SOQL and DML found 
 
-if not overallFlowFound:
-    print('No Active Flows with identified SOQL or DML statements inside Loops.')
+def commandLineParser(flowsPath, orgName):
+    overallFlowFound = False
+    #iterate directory - go through all the files in the folder above and call the main function
+    #only look at xml files
+    for filePath in [f for f in flowsPath.iterdir() if f.suffix == '.xml']:
+        if loopCheck(flowsPath, filePath.name, orgName):
+            overallFlowFound = True
+    return overallFlowFound
+
+
+if __name__ == "__main__":
+    overallFlowFound = commandLineParser(Path(argv[1]), argv[2])
+    if not overallFlowFound:
+        print('No Active Flows with identified SOQL or DML statements inside Loops.')


### PR DESCRIPTION
Updated the "narrow" version of the loop finder to be more accurate and account for input values in DML elements as well as filter values. Previously this class would not find flows that references the loop's defined single loop variable instead of the loop name itself. It also didn't check for the loop name in inputs, only filters. 

Added new class for finding record-triggered flows with missing entry criteria. 

Updated Readme. 